### PR TITLE
Redux

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -67,7 +67,7 @@ rate-limit@1.0.4
 react-meteor-data@0.2.9
 reactive-dict@1.1.7
 reactive-var@1.0.9
-reactrouter:react-router-ssr@3.1.1
+reactrouter:react-router-ssr@3.1.3
 reload@1.1.8
 retry@1.0.7
 routepolicy@1.0.10

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "react-addons-pure-render-mixin": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-mixin": "^3.0.3",
-    "react-router": "^2.4.0"
+    "react-redux": "^4.4.5",
+    "react-router": "^2.4.0",
+    "react-router-redux": "^4.0.5",
+    "redux": "^3.5.2",
+    "redux-devtools": "^3.3.1",
+    "redux-devtools-dock-monitor": "^1.1.1",
+    "redux-devtools-log-monitor": "^1.0.11"
   },
   "devDependencies": {
     "webpack": "^1.13.0",

--- a/src/TodoApp/client/components/AboutPage.jsx
+++ b/src/TodoApp/client/components/AboutPage.jsx
@@ -1,0 +1,13 @@
+import { Component } from 'react';
+
+export default class AboutPage extends Component {
+
+  render() {
+    return (
+      <div>
+        <h1>about page</h1>
+      </div>
+    );
+  }
+
+}

--- a/src/TodoApp/client/components/TodoApp.jsx
+++ b/src/TodoApp/client/components/TodoApp.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import ReactMixin from 'react-mixin';
+import { Link } from 'react-router';
 
 import TodoHeader from './TodoHeader';
 import TodoList from './TodoList';
@@ -51,6 +52,7 @@ export default class TodoMain extends Component {
               toggleHideCompleted={this.handleToggleHideCompleted}
           />
           <TodoList tasks={this.data.tasks} />
+          <Link to="/about">About</Link>
         </div>
     );
   }

--- a/src/TodoApp/client/configureStore.js
+++ b/src/TodoApp/client/configureStore.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {createStore, combineReducers, compose, applyMiddleware} from 'redux';
+import {routerReducer, routerMiddleware} from 'react-router-redux';
+
+export function configureStore(history, initialState) {
+  const reducer = combineReducers({
+    routing: routerReducer
+  });
+
+  const store = createStore(
+    reducer,
+    initialState,
+    compose(
+      applyMiddleware(
+        routerMiddleware(history)
+      ),
+      window.devToolsExtension ? window.devToolsExtension() : f => f
+    )
+  );
+
+  return store
+}

--- a/src/TodoApp/client/configureStore.js
+++ b/src/TodoApp/client/configureStore.js
@@ -14,7 +14,7 @@ export function configureStore(history, initialState) {
       applyMiddleware(
         routerMiddleware(history)
       ),
-      window.devToolsExtension ? window.devToolsExtension() : f => f
+      Meteor.isClient && window.devToolsExtension ? window.devToolsExtension() : f => f
     )
   );
 

--- a/src/TodoApp/client/routes.jsx
+++ b/src/TodoApp/client/routes.jsx
@@ -1,6 +1,10 @@
 import { Route } from 'react-router';
 import TodoApp from './components/TodoApp';
+import AboutPage from './components/AboutPage';
 
 export default (
-  <Route path="/" component={TodoApp} />
+  <Route>
+    <Route path="/" component={TodoApp} />
+    <Route path="/about" component={AboutPage} />
+  </Route>
 );

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,41 +1,55 @@
 import { ReactRouterSSR } from 'meteor/reactrouter:react-router-ssr';
 import { Provider } from 'react-redux';
-import { browserHistory } from 'react-router';
+import { Router, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 
 import todoRoutes from 'TodoApp/client/routes';
-import { configureStore } from 'TodoApp/client/configureStore';
+import {configureStore} from 'TodoApp/client/configureStore';
 
-// Data that is populated by hooks during startup
+
+// Data that is populated by hooks during startup (no, they won't populate - isolated scopes to each other -.-)
 let history;
 let store;
 let initialState;
 
-// Use history hook to get a reference to the history object
+// 1.(ssr: 2.) Use history hook to get a reference to the history object
 const historyHook = newHistory => {
-    history = newHistory;
+  history = newHistory;
 
-    // if (Meteor.isServer) {
-    //     store = configureStore(history);
-    //     history = syncHistoryWithStore(history, store);
-    // }
+  // if (Meteor.isServer) {
+  //     store = configureStore(history);
+  //     history = syncHistoryWithStore(history, store);
+  // }
 };
 
 
-// Pass the state of the store as the object to be dehydrated server side
+// (ssr: 1.) Pass the state of the store as the object to be dehydrated server side
 const dehydrateHook = () => store.getState();
 
-// Take the rehydrated state and use it as the initial state client side
+// 2. Take the rehydrated state and use it as the initial state client side
 const rehydrateHook = state => initialState = state;
 
-// Create a redux store and pass into the redux Provider wrapper
+// 3. Create a redux store and pass into the redux Provider wrapper
 const wrapperHook = app => {
-    store = configureStore(browserHistory, initialState);
-    history = syncHistoryWithStore(browserHistory, store);
-    return <Provider store={store}>{app}</Provider>;
+  store = configureStore(history, initialState);
+  history = syncHistoryWithStore(history, store);
+
+  // this line of code, like in the readme proposed - falls back to hash-routing oO
+  // return <Provider store={store}>{app}</Provider>;
+
+  // while this block where i overwrite the history of Router again with the new "enhanced" one from redux-router - works as expected
+  return (
+    <Provider store={store}>
+      {/* it's the only way we can attach the enhanced history object to the Router :-/ */}
+      <Router
+        history={history}
+        children={todoRoutes} />
+    </Provider>
+  );
 };
 
-const clientOptions = { historyHook, rehydrateHook, wrapperHook };
-const serverOptions = { historyHook, dehydrateHook };
+const clientOptions = {historyHook, rehydrateHook, wrapperHook};
+const serverOptions = {historyHook, dehydrateHook};
 
+// passing "todoRoutes" becomes useless - as we're overwriting the full "app" prop given in wrapperHook again -> pass custom props right there
 ReactRouterSSR.Run(todoRoutes, clientOptions, serverOptions);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,9 +1,41 @@
-import { Route } from 'react-router';
 import { ReactRouterSSR } from 'meteor/reactrouter:react-router-ssr';
-import todoRoutes from 'TodoApp/client/routes';
+import { Provider } from 'react-redux';
+import { browserHistory } from 'react-router';
+import { syncHistoryWithStore } from 'react-router-redux';
 
-ReactRouterSSR.Run(
-  <Route>
-    {todoRoutes}
-  </Route>
-);
+import todoRoutes from 'TodoApp/client/routes';
+import { configureStore } from 'TodoApp/client/configureStore';
+
+// Data that is populated by hooks during startup
+let history;
+let store;
+let initialState;
+
+// Use history hook to get a reference to the history object
+const historyHook = newHistory => {
+    history = newHistory;
+
+    // if (Meteor.isServer) {
+    //     store = configureStore(history);
+    //     history = syncHistoryWithStore(history, store);
+    // }
+};
+
+
+// Pass the state of the store as the object to be dehydrated server side
+const dehydrateHook = () => store.getState();
+
+// Take the rehydrated state and use it as the initial state client side
+const rehydrateHook = state => initialState = state;
+
+// Create a redux store and pass into the redux Provider wrapper
+const wrapperHook = app => {
+    store = configureStore(browserHistory, initialState);
+    history = syncHistoryWithStore(browserHistory, store);
+    return <Provider store={store}>{app}</Provider>;
+};
+
+const clientOptions = { historyHook, rehydrateHook, wrapperHook };
+const serverOptions = { historyHook, dehydrateHook };
+
+ReactRouterSSR.Run(todoRoutes, clientOptions, serverOptions);


### PR DESCRIPTION
Hi there!

i was having a hard time trying to get redux running on top of this wonderful stack. the readme is giving a really good initial kick off how to write it - but it lacks some important pieces by leaving out an example for the "./store" file and one other very important thing - the `history = syncHistoryWithStore(history, store);` call - without that, a normal app routing with a `<Link />` won't update the redux store!

so i thought myself - why not creating another branch on top of the `kickstart-meteor-react-router` (the only one with working SSR implementation out-of-the-box) called "redux" for example, where we basically show off how to implement redux router with fully working SSR :)

now here is my attempt to do that - i'm still a total beginner in the react-world so... please correct me if i'm wrong ^^

my hard time was because of two things:

* first i run into strange bugs - my local "history" and "initialState" didn't pouplated correctly, so when i hit the "wrapperHook", history wasn't there! i tried then first some nasty hacks until i realized that the my client-code was showing off a "createReduxStore" function.. which turned out is an obsolete function of some older days, and isn't even existing anymore in the current code base! fortunately the explicit update of the reactrouter:react-router-ssr@3.1.3 - to 3.1.3 was fixing this strange thing!

* secondly and lastly - the missing piece with the `syncHistoryWithStore`... i first wanted to try it on my own my distinct with "Meteor.isClient/isServer" and using a imported "browserHistory" or then a "memoryHistory".. created by the "req.url"... *dang* -> i don't have "req.url" in wrapperHook.. so again..

then i moved on to debug down the full package and i realized that the local variable "history" is getting populated correctly already by the package itself (yay!) - but remember, first those variables sill where undefined.. till i updated - now this started to work, hurray!! 👍 

but i'm still struggling with this one piece - see my wrapperHook implementation... 

-> when i add the missing `syncHistoryWithStore` call,  i get back an "enhanced" history object, taking care of now to update my redux-store accordingly on every routing change..

but because right before the wrapper hook, the full {app} object is built with the including `<Router history={history} />` binding inside - it's impossible to update this already given history object again, because we can't just update an already given prop right (and it's good this way)..

so i ended up by returning a complete new stack of elements:

```
<Provider store={store}>
      {/* it's the only way we can attach the enhanced history object to the Router :-/ */}
      <Router
        history={history}
        children={todoRoutes} />
    </Provider>
```

It fells pretty wrong but it's working like a charm now - so please help me out how to clean this and then we could maybe establish such a branch on the official repository so future people will have it easier